### PR TITLE
Pagination for Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ GunBroker::Item.find(123)
 To raise a `GunBroker::Error::NotFound` exception if no Item can be found, use `Item.find!`.
 
 
+### GunBroker::ItemsAsPage
+
+Represents a page of items (listings) on GunBroker, allowing for querying to be done in chunks to prevent memory leaks.  The `ItemsAsPage#fetch_items` method fetches the associated items for the given page.
+
+```ruby
+items_as_pages.each do |page_of_items|
+  page_of_items.fetch_items.each do |item|
+    puts item.id
+  end
+end
+```
+
+
 ### GunBroker::Category
 
 Returns GunBroker category responses.  To get an array of all categories, call `Category.all`.

--- a/lib/gun_broker.rb
+++ b/lib/gun_broker.rb
@@ -5,6 +5,7 @@ require 'gun_broker/category'
 require 'gun_broker/error'
 require 'gun_broker/feedback'
 require 'gun_broker/item'
+require 'gun_broker/items_as_page'
 require 'gun_broker/response'
 require 'gun_broker/user'
 

--- a/lib/gun_broker/items_as_page.rb
+++ b/lib/gun_broker/items_as_page.rb
@@ -15,7 +15,7 @@ module GunBroker
       })
       response = GunBroker::API.get(@attributes[:endpoint], @attributes[:params], @attributes[:token_header])
 
-      response.map { |result| GunBroker::Item.new(result) }
+      response['results'].map { |result| GunBroker::Item.new(result) }
     end
 
   end

--- a/lib/gun_broker/items_as_page.rb
+++ b/lib/gun_broker/items_as_page.rb
@@ -1,5 +1,3 @@
-require 'gun_broker/item/constants'
-
 module GunBroker
   # Represents a page of GunBroker items (listings).
   class ItemsAsPage

--- a/lib/gun_broker/items_as_page.rb
+++ b/lib/gun_broker/items_as_page.rb
@@ -1,0 +1,24 @@
+require 'gun_broker/item/constants'
+
+module GunBroker
+  # Represents a page of GunBroker items (listings).
+  class ItemsAsPage
+
+    # @param attrs [Hash] The attributes required to fetch items from the API.
+    def initialize(attributes = {})
+      @attributes = attributes
+    end
+
+    # @return [Array<Item>]
+    def fetch_items
+      @attributes.params.merge!({
+        'PageIndex' => @attributes.page_index,
+        'PageSize'  => @attributes.page_size
+      })
+      response = GunBroker::API.get(@attributes.endpoint, @attributes.params, @attributes.token_header)
+
+      response.map { |result| GunBroker::Item.new(result) }
+    end
+
+  end
+end

--- a/lib/gun_broker/items_as_page.rb
+++ b/lib/gun_broker/items_as_page.rb
@@ -9,11 +9,11 @@ module GunBroker
 
     # @return [Array<Item>]
     def fetch_items
-      @attributes.params.merge!({
-        'PageIndex' => @attributes.page_index,
-        'PageSize'  => @attributes.page_size
+      @attributes[:params].merge!({
+        'PageIndex' => @attributes[:page_index],
+        'PageSize'  => @attributes[:page_size]
       })
-      response = GunBroker::API.get(@attributes.endpoint, @attributes.params, @attributes.token_header)
+      response = GunBroker::API.get(@attributes[:endpoint], @attributes[:params], @attributes[:token_header])
 
       response.map { |result| GunBroker::Item.new(result) }
     end

--- a/lib/gun_broker/user.rb
+++ b/lib/gun_broker/user.rb
@@ -86,6 +86,13 @@ module GunBroker
       @items_delegate ||= ItemsDelegate.new(self)
     end
 
+    # (see ItemsAsPagesDelegate)
+    # See the {ItemsAsPagesDelegate} docs.
+    # @return [ItemsAsPagesDelegate]
+    def items_as_pages(options = {})
+      @items_as_pages_delegate ||= ItemsAsPagesDelegate.new(self, options)
+    end
+
     private
 
     # @return [Boolean] `true` if `@username` is present and either `@password` *or* `@token` is present.

--- a/lib/gun_broker/user.rb
+++ b/lib/gun_broker/user.rb
@@ -1,5 +1,6 @@
 require 'gun_broker/token_header'
 require 'gun_broker/user/items_delegate'
+require 'gun_broker/user/items_as_pages_delegate'
 
 module GunBroker
   # Represents a GunBroker User.

--- a/lib/gun_broker/user/items_as_pages_delegate.rb
+++ b/lib/gun_broker/user/items_as_pages_delegate.rb
@@ -24,54 +24,54 @@ module GunBroker
       # @return [Array<ItemsAsPage>]
       def all
         # NOTE: this endpoint will not return items that were sold
-        @all ||= build_pages(:Items, { 'SellerName' => @user.username })
+        @all ||= build_pages_for(:Items, { 'SellerName' => @user.username })
       end
 
       # Returns pages for all items the User has bid on.
       # @note {API#get! GET} /ItemsBidOn
       # @return [Array<ItemsAsPage>]
       def bid_on
-        @bid_on ||= build_pages(:ItemsBidOn)
+        @bid_on ||= build_pages_for(:ItemsBidOn)
       end
 
       # Returns pages for items the User has bid on, but not won.
       # @note {API#get! GET} /ItemsNotWon
       # @return [Array<ItemsAsPage>]
       def not_won
-        @not_won ||= build_pages(:ItemsNotWon)
+        @not_won ||= build_pages_for(:ItemsNotWon)
       end
 
       # Returns pages for items that are currently selling.
       # @note {API#get! GET} /Items
       # @return [Array<ItemsAsPage>]
       def selling
-        @selling ||= build_pages(:Items, { 'SellerName' => @user.username })
+        @selling ||= build_pages_for(:Items, { 'SellerName' => @user.username })
       end
 
       # Returns pages for items the User has sold.
       # @note {API#get! GET} /ItemsSold
       # @return [Array<ItemsAsPage>]
       def sold
-        @sold ||= build_pages(:ItemsSold)
+        @sold ||= build_pages_for(:ItemsSold)
       end
 
       # Returns pages for items that were listed, but not sold.
       # @note {API#get! GET} /ItemsUnsold
       # @return [Array<ItemsAsPage>]
       def unsold
-        @unsold ||= build_pages(:ItemsUnsold)
+        @unsold ||= build_pages_for(:ItemsUnsold)
       end
 
       # Returns pages for items the User has won.
       # @note {API#get! GET} /ItemsWon
       # @return [Array<ItemsAsPage>]
       def won
-        @won ||= build_pages(:ItemsWon)
+        @won ||= build_pages_for(:ItemsWon)
       end
 
       private
 
-      def build_pages(endpoint, params = {})
+      def build_pages_for(endpoint, params = {})
         endpoint = ['/', endpoint.to_s].join
         _token_header = token_header(@user.token)
         response = GunBroker::API.get(endpoint, params.merge({ 'PageSize' => 1 }), _token_header)

--- a/lib/gun_broker/user/items_as_pages_delegate.rb
+++ b/lib/gun_broker/user/items_as_pages_delegate.rb
@@ -1,0 +1,98 @@
+require 'gun_broker/token_header'
+
+module GunBroker
+  class User
+    # Used to scope {ItemsAsPage} actions by {User}.
+    class ItemsAsPagesDelegate
+
+      include GunBroker::TokenHeader
+
+      # @param user [User] A {User} instance to scope item pages by.
+      # @param options [Hash] { items_per_page => <number of desired items per page> (Integer) }.
+      def initialize(user, options = {})
+        max_page_size = GunBroker::API::PAGE_SIZE
+        @user = user
+        @items_per_page = options.fetch(:items_per_page, max_page_size)
+
+        if @items_per_page > max_page_size
+          raise ArgumentError.new("`items_per_page` may not exceed #{max_page_size}")
+        end
+      end
+
+      # Returns pages for all the the User's items (both selling and not selling).
+      # @note {API#get! GET} /Items
+      # @return [Array<ItemsAsPage>]
+      def all
+        # NOTE: this endpoint will not return items that were sold
+        @all ||= build_pages(:Items, { 'SellerName' => @user.username })
+      end
+
+      # Returns pages for all items the User has bid on.
+      # @note {API#get! GET} /ItemsBidOn
+      # @return [Array<ItemsAsPage>]
+      def bid_on
+        @bid_on ||= build_pages(:ItemsBidOn)
+      end
+
+      # Returns pages for items the User has bid on, but not won.
+      # @note {API#get! GET} /ItemsNotWon
+      # @return [Array<ItemsAsPage>]
+      def not_won
+        @not_won ||= build_pages(:ItemsNotWon)
+      end
+
+      # Returns pages for items that are currently selling.
+      # @note {API#get! GET} /Items
+      # @return [Array<ItemsAsPage>]
+      def selling
+        @selling ||= build_pages(:Items, { 'SellerName' => @user.username })
+      end
+
+      # Returns pages for items the User has sold.
+      # @note {API#get! GET} /ItemsSold
+      # @return [Array<ItemsAsPage>]
+      def sold
+        @sold ||= build_pages(:ItemsSold)
+      end
+
+      # Returns pages for items that were listed, but not sold.
+      # @note {API#get! GET} /ItemsUnsold
+      # @return [Array<ItemsAsPage>]
+      def unsold
+        @unsold ||= build_pages(:ItemsUnsold)
+      end
+
+      # Returns pages for items the User has won.
+      # @note {API#get! GET} /ItemsWon
+      # @return [Array<ItemsAsPage>]
+      def won
+        @won ||= build_pages(:ItemsWon)
+      end
+
+      private
+
+      def build_pages(endpoint, params = {})
+        endpoint = ['/', endpoint.to_s].join
+        _token_header = token_header(@user.token)
+        response = GunBroker::API.get(endpoint, params.merge({ 'PageSize' => 1 }), _token_header)
+        number_of_pages = (response['count'] / @items_per_page.to_f).ceil
+        items_as_pages = []
+
+        number_of_pages.times do |page_number|
+          page_number += 1
+          attrs = {
+            page_size:    @items_per_page,
+            page_index:   page_number,
+            endpoint:     endpoint,
+            params:       params,
+            token_header: _token_header
+          }
+
+          items_as_pages << GunBroker::ItemsAsPage.new(attrs)
+        end
+
+        items_as_pages
+      end
+    end
+  end
+end

--- a/lib/gun_broker/user/items_delegate.rb
+++ b/lib/gun_broker/user/items_delegate.rb
@@ -24,7 +24,6 @@ module GunBroker
 
       # Returns all the items the User has bid on.
       # @note {API#get! GET} /ItemsBidOn
-      # @raise (see #all)
       # @return [Array<Item>]
       def bid_on
         @bid_on ||= fetch_items(:ItemsBidOn)
@@ -61,7 +60,6 @@ module GunBroker
       end
 
       # Same as {#find} but raises GunBroker::Error::NotFound if no item is found.
-      # @raise (see #all)
       # @raise [GunBroker::Error::NotFound] If the User has no Item with `item_id`.
       # @return [Item] Returns the Item or `nil` if no Item found.
       def find!(item_id)
@@ -72,7 +70,6 @@ module GunBroker
 
       # Items the User has bid on, but not won.
       # @note {API#get! GET} /ItemsNotWon
-      # @raise (see #all)
       # @return [Array<Item>]
       def not_won
         @not_won ||= fetch_items(:ItemsNotWon)
@@ -96,7 +93,6 @@ module GunBroker
       # Items the User has sold.
       # @param options [Hash] {ItemID=>ItemID}.
       # @note {API#get! GET} /ItemsSold
-      # @raise (see #all)
       # @return [Array<Item>]
       def sold(options = {})
         params = {
@@ -108,7 +104,6 @@ module GunBroker
 
       # Items that were listed, but not sold.
       # @note {API#get! GET} /ItemsUnsold
-      # @raise (see #all)
       # @return [Array<Item>]
       def unsold(options = {})
         params = {
@@ -140,7 +135,6 @@ module GunBroker
 
       # Items the User has won.
       # @note {API#get! GET} /ItemsWon
-      # @raise (see #all)
       # @return [Array<Item>]
       def won
         @won ||= fetch_items(:ItemsWon)
@@ -152,16 +146,16 @@ module GunBroker
         endpoint = ['/', endpoint.to_s].join
         params.merge!({ 'PageSize' => GunBroker::API::PAGE_SIZE })
         response = GunBroker::API.get(endpoint, params, token_header(@user.token))
-        pages = (response['count'] / GunBroker::API::PAGE_SIZE.to_f).ceil
+        number_of_pages = (response['count'] / GunBroker::API::PAGE_SIZE.to_f).ceil
 
-        if pages > 1
+        if number_of_pages > 1
           _items_from_results = items_from_results(response['results'])
 
-          pages.times do |page|
-            page += 1
-            next if page == 1
+          number_of_pages.times do |page_number|
+            page_number += 1
+            next if page_number == 1
 
-            params.merge!({ 'PageIndex' => page })
+            params.merge!({ 'PageIndex' => page_number })
             response = GunBroker::API.get(endpoint, params, token_header(@user.token))
             _items_from_results.concat(items_from_results(response['results']))
           end


### PR DESCRIPTION
Allow Items to be paginated so that they can be processed in memory-friendly chunks instead of having to load the whole megillah into memory when the seller has, potentially, thousands of Items.